### PR TITLE
Add missing `HasScopeDirective` to example usage.

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ npm install --save graphql-auth-directives
 Then import the schema directives you'd like to use and attach them during your GraphQL schema construction. For example using [neo4j-graphql.js' `makeAugmentedSchema`](https://grandstack.io/docs/neo4j-graphql-js-api.html#makeaugmentedschemaoptions-graphqlschema):
 
 ```
-import { IsAuthenticatedDirective, HasRoleDirective } from "graphql-auth-directives";
+import { IsAuthenticatedDirective, HasRoleDirective, HasScopeDirective } from "graphql-auth-directives";
 const augmentedSchema = makeAugmentedSchema({
   typeDefs,
   schemaDirectives: {


### PR DESCRIPTION
In the example, `HasScopeDirective` is used, though not imported.