### PR TITLE
check for token inside the cookies

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -10,17 +10,22 @@ import {
 } from "graphql";
 
 const verifyAndDecodeToken = ({ context }) => {
-  const req = context instanceof IncomingMessage ? context : (context.req || context.request);
+  const req =
+    context instanceof IncomingMessage
+      ? context
+      : context.req || context.request;
 
   if (
-    !req ||
-    !req.headers ||
-    (!req.headers.authorization && !req.headers.Authorization)
+    (!req ||
+      !req.headers ||
+      (!req.headers.authorization && !req.headers.Authorization)) &&
+    (!req.cookies && !req.cookies.token)
   ) {
     throw new AuthorizationError({ message: "No authorization token." });
   }
 
-  const token = req.headers.authorization || req.headers.Authorization;
+  const token =
+    req.headers.authorization || req.headers.Authorization || req.cookies.token;
   try {
     const id_token = token.replace("Bearer ", "");
     const JWT_SECRET = process.env.JWT_SECRET;


### PR DESCRIPTION
For webapp is not too secure save the token in the localstorage, so is better save it in a cookie, with this PR I would like to check also the cookies to authenticate the user.

Even better I think it's better to define a var inside the context and use that var instead of search the token inside the header...something like:

```
const server = new ApolloServer({
  schema,
  context: ({ req }) => {
    const token = req.headers.token || req.cookies.token;
    return { req, token };
  }
});
```

and then on the directive do something like:
```
const token = context.token;
```

in this way the developer it's more free

If this make sense I'm going to add some tests