### PR TITLE
Remove the need to verify the token per request

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,11 +85,16 @@ const client = new ApolloClient({
 
 Configuration is done via environment variables.
 
-(optional)
-If you set the `JWT_SECRET` environment variable, any token recieved will be verified against the secret that is stored here. Otherwise tokens will be simply decoded and remain unverified:
+(required)
+There are two variables to control how tokens are processed.
+If you would like the server to verify the tokens used in a request, you must provide the secret used to encode the token in the `JWT_SECRET` variable. Otherwise you will need to set `JWT_NO_VERIFY` to true.
 
 ```sh
-export JWT_SECRET=><YOUR_JWT_SECRET_KEY_HERE>
+export JWT_NO_VERIFY=true //Server does not have the secret, but will need to decode tokens
+```
+or
+```sh
+export JWT_SECRET=><YOUR_JWT_SECRET_KEY_HERE> //Server has the secret and will verify autheniticty
 ```
 
 (optional)
@@ -106,6 +111,20 @@ Set:
 ```sh
 export AUTH_DIRECTIVES_ROLE_KEY=https://grandstack.io/roles
 ```
+
+## Running Tests Locally
+
+1. create ./test/helpers/.env
+2. add relevant values
+3. run the test server
+```sh
+npx babel-node test/helpers/test-setup.js
+```
+4. run the tests
+```sh
+npx ava test/*.js
+```
+
 
 ## Test JWTs
 

--- a/README.md
+++ b/README.md
@@ -85,8 +85,8 @@ const client = new ApolloClient({
 
 Configuration is done via environment variables.
 
-(required)
-You must set the `JWT_SECRET` environment variable:
+(optional)
+If you set the `JWT_SECRET` environment variable, any token recieved will be verified against the secret that is stored here. Otherwise tokens will be simply decoded and remain unverified:
 
 ```sh
 export JWT_SECRET=><YOUR_JWT_SECRET_KEY_HERE>

--- a/src/index.js
+++ b/src/index.js
@@ -85,7 +85,7 @@ export class HasScopeDirective extends SchemaDirectiveVisitor {
 
   visitObject(obj) {
     const fields = obj.getFields();
-    const expectedScopes = this.args.roles;
+    const expectedScopes = this.args.scopes;
 
     Object.keys(fields).forEach(fieldName => {
       const field = fields[fieldName];

--- a/src/index.js
+++ b/src/index.js
@@ -23,9 +23,9 @@ const verifyAndDecodeToken = ({ context }) => {
   const token = req.headers.authorization || req.headers.Authorization;
   try {
     const id_token = token.replace("Bearer ", "");
-    const JWT_SECRET = process.env.JWT_SECRET;
+    const {JWT_SECRET, JWT_NO_VERIFY} = process.env;
 
-    if (!JWT_SECRET) {
+    if (!JWT_SECRET && JWT_NO_VERIFY) {
       return jwt.decode(id_token)
     } else {
       return jwt.verify(id_token, JWT_SECRET, {

--- a/src/index.js
+++ b/src/index.js
@@ -26,15 +26,12 @@ const verifyAndDecodeToken = ({ context }) => {
     const JWT_SECRET = process.env.JWT_SECRET;
 
     if (!JWT_SECRET) {
-      throw new Error(
-        "No JWT secret set. Set environment variable JWT_SECRET to decode token."
-      );
+      return jwt.decode(id_token)
+    } else {
+      return jwt.verify(id_token, JWT_SECRET, {
+        algorithms: ["HS256", "RS256"]
+      });
     }
-    const decoded = jwt.verify(id_token, JWT_SECRET, {
-      algorithms: ["HS256", "RS256"]
-    });
-
-    return decoded;
   } catch (err) {
     throw new AuthorizationError({
       message: "You are not authorized for this resource"

--- a/test/test.js
+++ b/test/test.js
@@ -52,7 +52,7 @@ test("No error with token", async t => {
 
   const headers = {
     Authorization:
-      "Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJHUkFORHN0YWNrIiwiaWF0IjoxNTQ5MTQ1Mjk0LCJleHAiOjE1ODA2ODEzMDcsImF1ZCI6ImdyYW5kc3RhY2suaW8iLCJzdWIiOiJib2JAbG9ibGF3LmNvbSIsIlJvbGUiOiJBRE1JTiIsIlNjb3BlIjpbIlVzZXI6UmVhZCIsIlVzZXI6Q3JlYXRlIiwiVXNlcjpVcGRhdGUiLCJVc2VyOkRlbGV0ZSJdfQ.nKADki8iKTpKqq3CVdrGAUrSzSBmFolWzYOsA_ULSdo"
+      "Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJHUkFORHN0YWNrIiwiaWF0IjoxNTQ5MTQ1Mjk0LCJleHAiOjE2OTE3ODEzMDcsImF1ZCI6ImdyYW5kc3RhY2suaW8iLCJzdWIiOiJib2JAbG9ibGF3LmNvbSIsIlJvbGUiOiJBRE1JTiIsIlNjb3BlIjpbIlVzZXI6UmVhZCIsIlVzZXI6Q3JlYXRlIiwiVXNlcjpVcGRhdGUiLCJVc2VyOkRlbGV0ZSJdfQ.WJffOec05r8KuzW76asax1iCzv5q4rwRv9kvFyw7c_E"
   };
 
   const client = new ApolloClient({
@@ -76,6 +76,7 @@ test("No error with token", async t => {
       t.pass();
     })
     .catch(error => {
+      console.error(error)
       t.fail();
     });
 });
@@ -86,7 +87,7 @@ test("Mutation resolver is not called when Auth fails", async t => {
   // This JWT does not contain User:Create scope claim
   const headers = {
     Authorization:
-      "Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJHUkFORHN0YWNrIiwiaWF0IjoxNTQ5MTQ1Mjk0LCJleHAiOjE1ODA2ODEzMDcsImF1ZCI6ImdyYW5kc3RhY2suaW8iLCJzdWIiOiJib2JAbG9ibGF3LmNvbSIsIlJvbGUiOiJBRE1JTiIsIlNjb3BlIjpbIlVzZXI6UmVhZCIsIlVzZXI6VXBkYXRlIiwiVXNlcjpEZWxldGUiXX0.cXOlwyZOi--tHmLyf32iC37JXGj4DrvdOsQVK5VHmuY"
+      "Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJHUkFORHN0YWNrIiwiaWF0IjoxNTQ5MTQ1Mjk0LCJleHAiOjE2OTE3ODEzMDcsImF1ZCI6ImdyYW5kc3RhY2suaW8iLCJzdWIiOiJib2JAbG9ibGF3LmNvbSIsIlJvbGUiOiJBRE1JTiIsIlNjb3BlIjpbIlVzZXI6UmVhZCIsIlVzZXI6VXBkYXRlIiwiVXNlcjpEZWxldGUiXX0.J3VrFNSKToK1cZNrwdbKp-8YkO74_tkp82l3n39ZnK0"
   };
 
   const client = new ApolloClient({


### PR DESCRIPTION
## Description
This small change enables the user to optionally set the JWT_SECRET environment variable. 

## Related Issue
[Support for federated services](https://github.com/grand-stack/graphql-auth-directives/issues/10#issue-509092865)

## Motivation
I'm working on a project that leverage's AWS Cognito for user identities, and so I don't have access to the original key that is used to generate the token. It would be nice if there was functionality that allowed for tokens to be accepted even if they are unverified within this instance.