### PR TITLE
feat(FieldDefinitionVisitor): use default field resolver as fallback …

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -58,6 +58,7 @@ typings/
 .env
 
 .idea
+.vscode
 
 .DS_Store
 


### PR DESCRIPTION
This pull request aims to solve https://github.com/grand-stack/graphql-auth-directives/issues/8 by using a default field resolver for fields for which `field.resolve` is undefined when assigning `field.resolve` to a `next` variable.

https://github.com/grand-stack/graphql-auth-directives/compare/master...nino-vrijman:feat-default-field-resolvers-patch?expand=1#diff-1fdf421c05c1140f6d71444ea2b27638R79